### PR TITLE
Add fedora 23 as a distro option to avoid ValueError

### DIFF
--- a/broot/root.py
+++ b/broot/root.py
@@ -54,7 +54,7 @@ class Root:
 
         if distro == "debian":
             self._builder = DebianBuilder(self)
-        elif distro in ["fedora", "fedora-20"]:
+        elif distro in ["fedora", "fedora-20", "fedora-23"]:
             self._builder = FedoraBuilder(self, distro)
         else:
             raise ValueError("Unknown distro %s" % distro)


### PR DESCRIPTION
sugar-build `./osbuild pull` fails because the name of the distro is not listed between the possible choices

The error: 

``` bash
julio@linux-hrqx:~/repo/sugar-build> ./osbuild pull

= Setup the host build system =

* Create the python virtualenv
* Install python packages
* Pull latest sugar-build
* Setup the build root

$ sudo broot setup
root's password:
Traceback (most recent call last):
  File "/home/julio/repo/sugar-build/build/out/sandbox-host/install/bin/broot", line 5, in <module>
    main.main()
  File "/home/julio/repo/sugar-build/build/out/sandbox-host/install/lib/python2.7/site-packages/broot/main.py", line 80, in main
    if not cmd_function(options, other_args):
  File "/home/julio/repo/sugar-build/build/out/sandbox-host/install/lib/python2.7/site-packages/broot/main.py", line 39, in cmd_setup
    root = Root()
  File "/home/julio/repo/sugar-build/build/out/sandbox-host/install/lib/python2.7/site-packages/broot/root.py", line 60, in __init__
    raise ValueError("Unknown distro %s" % distro)
ValueError: Unknown distro fedora-23
```
